### PR TITLE
fix: register function to not throw error if metric name already exists

### DIFF
--- a/System/Metrics.hs
+++ b/System/Metrics.hs
@@ -209,7 +209,13 @@ register name sample store = do
                                               stateMetrics
                              }
                      in (state', ())
-            True  -> alreadyInUseError name
+            True  ->
+              let
+                -- delete the metrics if it already exists
+                !state' = state { stateMetrics =  M.delete name stateMetrics }
+                -- re-register it again
+                !state'' = state' { stateMetrics = M.insert name (Left sample) stateMetrics }
+              in (state'', ())
 
 -- | Raise an exception indicating that the metric name is already in
 -- use.


### PR DESCRIPTION
If the metric name already exists, instead of throwing error, the register function unregisters it, and re-registers the metric again.
