### PR TITLE
Support GHC 9.2

### DIFF
--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -28,7 +28,7 @@ common library-build-depends
     atomic-primops ^>= 0.8.4,
     containers >= 0.5 && < 0.7,
     ghc-prim < 0.9,
-    hashable >= 1.3.0.0 && < 1.4,
+    hashable >= 1.3.0.0 && < 1.5,
     inspection-testing ^>= 0.4.2.3,
     primitive ^>= 0.7.1.0,
     text < 1.3,

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -24,10 +24,10 @@ common common-all
 
 common library-build-depends
   build-depends:
-    base >= 4.6 && < 4.15,
+    base >= 4.6 && < 4.17,
     atomic-primops ^>= 0.8.4,
     containers >= 0.5 && < 0.7,
-    ghc-prim < 0.7,
+    ghc-prim < 0.9,
     hashable >= 1.3.0.0 && < 1.4,
     inspection-testing ^>= 0.4.2.3,
     primitive ^>= 0.7.1.0,

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -24,10 +24,10 @@ common common-all
 
 common library-build-depends
   build-depends:
-    ghc-prim < 0.7,
     base >= 4.6 && < 4.15,
     atomic-primops ^>= 0.8.4,
     containers >= 0.5 && < 0.7,
+    ghc-prim < 0.7,
     hashable >= 1.3.0.0 && < 1.4,
     inspection-testing ^>= 0.4.2.3,
     primitive ^>= 0.7.1.0,

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -103,7 +103,6 @@ test-suite ekg-core-test
     ekg-core-benchmark,
     async ^>= 2.2.1,
     containers >= 0.5 && < 0.7,
-    generic-random ^>= 1.4.0.0,
     hspec ^>= 2.8.2,
     hspec-smallcheck ^>= 0.5.2,
     HUnit ^>= 1.6.2.0,


### PR DESCRIPTION
This PR relaxes the dependency bounds for `ekg-core` to support GHC 9.2 and `hashable-1.4`. It also removes an unused dependency (`generic-random`).